### PR TITLE
fixes `no such file` error for windows users

### DIFF
--- a/packages/rincewind/src/commands/create.ts
+++ b/packages/rincewind/src/commands/create.ts
@@ -89,7 +89,7 @@ function findDefaultDir() {
 
 function initProgressEstimator() {
   if (!fs.existsSync(envPaths("rincewind").cache))
-    fs.mkdirSync(envPaths("rincewind").cache);
+    fs.mkdirSync(envPaths("rincewind").cache, { recursive: true });    
   const storagePath = path.join(
     envPaths("rincewind").cache,
     ".progress-estimator"


### PR DESCRIPTION
```
Error: ENOENT: no such file or directory, mkdir 'C:/Users/T/AppData/Local/rincewind-nodejs/Cache'
    at initProgressEstimator (C:/Users/T/AppData/Roaming/npm/node_modules/rincewind/lib/commands/create.js:86:12)
```